### PR TITLE
fix: Include license files in published crates

### DIFF
--- a/macros/LICENSE-APACHE
+++ b/macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macros/LICENSE-MIT
+++ b/macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Both the Apache-2.0 and MIT licenses require that redistributed sources contain a copy of the original license text. This is currently not the case for `async-generic` as published on crates.io. I'm packaging it for Fedora Linux as a new dependency of `sequoia-keystore`, and having license files is one of the prerequisites.

This PR just adds symbolic links to the `macros` subdirectory, which should be enough to have `cargo publish` include the files (unless you run `cargo publish` on an OS that does not support symbolic links, i.e. Windows).

It would be great if you could publish a new release with this change applied. 🙏🏼 