### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 1.1.1, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.2](https://github.com/scouten/async-generic/compare/async-generic-v1.1.1...async-generic-v1.1.2)
+_28 September 2024_
+
+### Fixed
+
+* Include license files in published crates ([#13](https://github.com/scouten/async-generic/pull/13))
+
 ## [1.1.1](https://github.com/scouten/async-generic/compare/async-generic-v1.1.0...async-generic-v1.1.1)
 _30 August 2024_
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-generic"
-version = "1.1.1"
+version = "1.1.2"
 description = "Write code that can be both async and synchronous without duplicating it."
 authors = ["Eric Scouten <git@scouten.me>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `async-generic`: 1.1.1 -> 1.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/scouten/async-generic/compare/async-generic-v1.1.1...async-generic-v1.1.2)

_28 September 2024_

### Fixed

* Include license files in published crates ([#13](https://github.com/scouten/async-generic/pull/13))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).