### PR TITLE
feat: implement `#[call_generic]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,58 @@ async fn main() {
 }
 ```
 
+Reduce boilerplate by annotating nested generic calls with `#[call_generic]`:
+
+```rust
+use async_generic::async_generic;
+
+#[async_generic]
+fn do_stuff() -> String {
+    #[call_generic]
+    do_nested_stuff()
+}
+
+#[async_generic]
+fn do_nested_stuff() -> String {
+    if _async {
+        my_async_nested_stuff().await
+    } else {
+        "not async".to_owned()
+    }
+}
+
+async fn my_async_nested_stuff() -> String {
+    "async".to_owned()
+}
+
+struct Do;
+
+impl Do {
+    #[async_generic]
+    fn stuff(&self) -> String {
+        #[call_generic]
+        self.nested_stuff()
+    }
+
+    #[async_generic]
+    fn nested_stuff(&self) -> String {
+        if _async {
+            my_async_nested_stuff().await
+        } else {
+            "not async".to_owned()
+        }
+    }
+}
+
+#[async_std::main]
+async fn main() {
+    println!("sync => {}", do_stuff());
+    println!("async => {}", do_stuff_async().await);
+    println!("sync method => {}", Do.stuff());
+    println!("async method => {}", Do.stuff_async().await);
+}
+```
+
 ## Why not use `maybe-async`?
 
 This crate is loosely derived from the excellent work of the [`maybe-async`](https://crates.io/crates/maybe-async) crate, but is intended to solve a subtly different problem.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,7 +21,7 @@ development = ["async-std", "async-trait"]
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["visit-mut", "full"] }
+syn = { version = "2.0", features = ["visit", "visit-mut", "full"] }
 
 [dev-dependencies]
 async-std = { version = "1.0", features = ["attributes"] }

--- a/macros/src/call_generic.rs
+++ b/macros/src/call_generic.rs
@@ -1,0 +1,114 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{
+    parse_quote,
+    spanned::Spanned,
+    visit::{self, Visit},
+    visit_mut::{self, VisitMut},
+    Attribute, Error, Expr, ExprCall, ExprMethodCall,
+};
+
+const ATTRIBUTE_NAME: &str = "call_generic";
+
+pub(super) fn parse_quote_call_generic(input: TokenStream) -> TokenStream {
+    let mut syntax_tree = syn::parse::<syn::File>(input.into()).unwrap();
+    GenericCallVisitor.visit_file_mut(&mut syntax_tree);
+    let mut visitor = OrphanAttributeVisitor::default();
+    visitor.visit_file(&syntax_tree);
+    if let Some(error_span) = visitor.error_span {
+        return Error::new(
+            error_span,
+            format!("{ATTRIBUTE_NAME} must be used on a method call or a function call."),
+        )
+        .into_compile_error();
+    }
+    quote! {#syntax_tree}
+}
+
+/// Finds an orphan attribute that hasn't been handled by [GenericCallVisitor].
+#[derive(Default)]
+struct OrphanAttributeVisitor {
+    error_span: Option<Span>,
+}
+
+impl Visit<'_> for OrphanAttributeVisitor {
+    fn visit_attribute(&mut self, node: &Attribute) {
+        if node
+            .path()
+            .segments
+            .last()
+            .map(|path| path.ident.to_string())
+            == Some(ATTRIBUTE_NAME.to_string())
+        {
+            self.error_span = Some(node.span());
+        }
+        visit::visit_attribute(self, node);
+    }
+}
+
+/// Finds and replaces a method call or function call annotated with `#[call_generic]`.
+/// This enables `#[call_generic]` to be used as a shorthand for
+/// ```rust,ignore
+/// if _sync {
+///     do_stuff();
+/// } else {
+///     do_stuff_async().await;
+/// }
+/// ```
+struct GenericCallVisitor;
+
+impl VisitMut for GenericCallVisitor {
+    fn visit_expr_mut(&mut self, node: &mut Expr) {
+        let async_call = match node {
+            Expr::MethodCall(expr) => construct_async_method_call(expr),
+            Expr::Call(expr) => construct_async_function_call(expr),
+            _ => None,
+        };
+
+        if let Some(async_call) = async_call {
+            let original_call = node.clone();
+            *node = parse_quote! {
+                if _async {
+                    #async_call.await
+                } else {
+                    #original_call
+               }
+            };
+            return;
+        }
+
+        // Delegate to the default impl to visit nested expressions.
+        visit_mut::visit_expr_mut(self, node);
+    }
+}
+
+fn construct_async_method_call(expr: &mut ExprMethodCall) -> Option<Expr> {
+    find_and_remove_generic_call_attr(&mut expr.attrs)?;
+    let mut async_expr = expr.clone();
+    async_expr.method = format_ident!("{}_async", async_expr.method);
+    Some(Expr::MethodCall(async_expr))
+}
+
+fn construct_async_function_call(expr: &mut ExprCall) -> Option<Expr> {
+    find_and_remove_generic_call_attr(&mut expr.attrs)?;
+    let mut async_expr = expr.clone();
+    let mut func = *async_expr.func;
+    let Expr::Path(ref mut path_expr) = &mut func else {
+        return None;
+    };
+    let last_segment = path_expr.path.segments.last_mut()?;
+    last_segment.ident = format_ident!("{}_async", last_segment.ident);
+    async_expr.func = Box::new(func);
+    Some(Expr::Call(async_expr))
+}
+
+fn find_and_remove_generic_call_attr(attributes: &mut Vec<Attribute>) -> Option<()> {
+    let length_before_removal = attributes.len();
+    attributes.retain(|attr| {
+        let Some(last_segment) = attr.path().segments.last() else {
+            return true;
+        };
+        last_segment.ident != ATTRIBUTE_NAME
+    });
+    (length_before_removal > attributes.len()).then_some(())
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 
+use call_generic::parse_quote_call_generic;
 use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2, TokenTree as TokenTree2};
 use quote::quote;
@@ -11,6 +12,7 @@ use syn::{
 
 use crate::desugar_if_async::DesugarIfAsync;
 
+mod call_generic;
 mod desugar_if_async;
 
 fn convert_sync_async(
@@ -54,6 +56,7 @@ fn convert_sync_async(
         tokens
     };
 
+    let tokens = parse_quote_call_generic(tokens);
     DesugarIfAsync { is_async }.desugar_if_async(tokens)
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -2,10 +2,12 @@
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("src/tests/pass/fun-with-types.rs");
+    t.pass("src/tests/pass/generic-call.rs");
     t.pass("src/tests/pass/generic-fn.rs");
     t.pass("src/tests/pass/generic-fn-with-visibility.rs");
     t.pass("src/tests/pass/struct-method-generic.rs");
 
+    t.compile_fail("src/tests/fail/generic-call-invalid-usage.rs");
     t.compile_fail("src/tests/fail/misuse-of-underscore-async.rs");
     t.compile_fail("src/tests/fail/no-async-fn.rs");
     t.compile_fail("src/tests/fail/no-impl.rs");

--- a/tests/src/tests/fail/generic-call-invalid-usage.rs
+++ b/tests/src/tests/fail/generic-call-invalid-usage.rs
@@ -1,0 +1,9 @@
+use async_generic::async_generic;
+
+#[async_generic]
+fn do_stuff() -> String {
+    #[call_generic]
+    "not a function call or method call"
+}
+
+fn main() {}

--- a/tests/src/tests/fail/generic-call-invalid-usage.stderr
+++ b/tests/src/tests/fail/generic-call-invalid-usage.stderr
@@ -1,0 +1,5 @@
+error: call_generic must be used on a method call or a function call.
+ --> src/tests/fail/generic-call-invalid-usage.rs:5:5
+  |
+5 |     #[call_generic]
+  |     ^

--- a/tests/src/tests/pass/generic-call.rs
+++ b/tests/src/tests/pass/generic-call.rs
@@ -1,0 +1,47 @@
+use async_generic::async_generic;
+
+#[async_generic]
+fn do_stuff() -> String {
+    #[call_generic]
+    do_nested_stuff()
+}
+
+#[async_generic]
+fn do_nested_stuff() -> String {
+    if _async {
+        my_async_nested_stuff().await
+    } else {
+        "not async".to_owned()
+    }
+}
+
+async fn my_async_nested_stuff() -> String {
+    "async".to_owned()
+}
+
+struct Do;
+
+impl Do {
+    #[async_generic]
+    fn stuff(&self) -> String {
+        #[call_generic]
+        self.nested_stuff()
+    }
+
+    #[async_generic]
+    fn nested_stuff(&self) -> String {
+        if _async {
+            my_async_nested_stuff().await
+        } else {
+            "not async".to_owned()
+        }
+    }
+}
+
+#[async_std::main]
+async fn main() {
+    println!("sync => {}", do_stuff());
+    println!("async => {}", do_stuff_async().await);
+    println!("sync method => {}", Do.stuff());
+    println!("async method => {}", Do.stuff_async().await);
+}


### PR DESCRIPTION
Adds `#[call_generic]`, a shorthand for nested calls of `#[async_generic]` functions.

Closes #19 